### PR TITLE
Ban FTAM

### DIFF
--- a/dist/kostentraeger-warnings.txt
+++ b/dist/kostentraeger-warnings.txt
@@ -31,7 +31,7 @@ AO05Q221.ke1
   message 153 - skipped invalid DFU 3: Unknown DFUProtokollSchluessel "011"
   message 202 - skipped invalid UEM 1: Refers to a non-existing DFU
 
-BK05Q221.ke2
+BK05Q221.ke3
   IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
   IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
   IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
@@ -42,6 +42,38 @@ BK05Q221.ke2
   IK 103524407 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
   IK 104526376 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
   IK 104529255 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 103524394 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 103524407 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 104526376 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 104529255 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+
+BK05Q321.ke0
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts data
+  IK 103524394 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
+  IK 103524407 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
+  IK 104526376 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
+  IK 104529255 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts data
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 101520078 (Mobil Krankenkasse) links to IK 101520078 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 103524394 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 103524407 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 104526376 (VIACTIV Krankenkasse) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
+  IK 104529255 (VIACTIV Krankenkasse Ost) links to IK 102193234 for data but neither that IK nor an IK it links to accepts SMTP (email)
 
 BN050321.ke0
   message 28 - skipped invalid DFU 1: Unknown DFUProtokollSchluessel "002"

--- a/src/kostentraeger/edifact/parser.ts
+++ b/src/kostentraeger/edifact/parser.ts
@@ -98,7 +98,7 @@ function validateLinks(institutions: KOTRMessage[]): string[] {
             } else {
                 const institution = institutionsByIK.get(vkg.verknuepfungspartnerIK)!
                 const acceptsData = isInstitutionAcceptingData(institution)
-                /* the link target to every link to a Datenannahmestelle without decrypt acapacity 
+                /* the link target to every link to a Datenannahmestelle without decrypt capacity 
                    must actually accept data */
                 if (vkg.ikVerknuepfungsartSchluessel == "02") {
                     if (!acceptsData) {

--- a/src/kostentraeger/index.ts
+++ b/src/kostentraeger/index.ts
@@ -13,8 +13,7 @@ import {
     Institution,
     InstitutionLink,
     InstitutionList,
-    PaperDataType,
-    PapierannahmestelleLink
+    PaperDataType
 } from "./types";
 
 
@@ -263,7 +262,7 @@ function findKostentraeger(
 
     // Step 3: Find if Datenannahmestelle has decryption authority and handle it if not
     let sendTo: Institution | undefined
-    if (encryptTo.transmissionMethods?.email || encryptTo.transmissionMethods?.ftam) {
+    if (encryptTo.transmission?.email) {
         /* if it accepts data itself, that's great! 
            The documentation is making it
            sound that even if this institution accepts data directly, one should look

--- a/src/kostentraeger/transformer.ts
+++ b/src/kostentraeger/transformer.ts
@@ -17,7 +17,7 @@ import {
     KVLocationSchluessel,
     PaperDataType,
     PapierannahmestelleLink,
-    ReceiptTransmissionMethods
+    ReceiptTransmission
 } from "./types"
 
 
@@ -196,7 +196,7 @@ function transformMessage(msg: KOTRMessage, interchangeValidityStartDate: Date):
 
         contacts: contacts.length > 0 ? contacts : undefined,
         addresses: msg.ansList.map((ans) => createAddress(ans)),
-        transmissionMethods: createReceiptTransmissionMethods(msg.uemList, msg.dfuList),
+        transmission: createReceiptTransmission(msg.uemList, msg.dfuList),
         kostentraegerLinks: kostentraegerLinks.length > 0 ? kostentraegerLinks : undefined,
         datenannahmestelleLinks: datenannahmestelleLinks.length > 0 ? datenannahmestelleLinks : undefined,
         untrustedDatenannahmestelleLinks: untrustedDatenannahmestelleLinks.length > 0 ? untrustedDatenannahmestelleLinks : undefined,
@@ -279,17 +279,16 @@ function createInstitutionLink(vkg: VKG): InstitutionLink {
     }
 }
 
-function createReceiptTransmissionMethods(uemList: UEM[], dfuList: DFU[]): ReceiptTransmissionMethods | undefined {
+function createReceiptTransmission(uemList: UEM[], dfuList: DFU[]): ReceiptTransmission | undefined {
     if (uemList.length == 0 || dfuList.length == 0) return undefined
 
-    let zeichensatzSchluessel, email, ftam
-    zeichensatzSchluessel = uemList.find((uem) => uem.uebermittlungsmediumSchluessel == "1")?.uebermittlungszeichensatzSchluessel
-    email = dfuList.find((dfu) => dfu.dfuProtokollSchluessel == "070")?.address
-    ftam = dfuList.find((dfu) => dfu.dfuProtokollSchluessel == "016")?.address
+    const zeichensatzSchluessel = uemList.find((uem) => uem.uebermittlungsmediumSchluessel == "1")?.uebermittlungszeichensatzSchluessel
+    const email = dfuList.find((dfu) => dfu.dfuProtokollSchluessel == "070")?.address
+
+    if (!email) return undefined
 
     return {
         email: email,
-        ftam: ftam,
         zeichensatz: zeichensatzSchluessel!
     }
 }

--- a/src/kostentraeger/types.ts
+++ b/src/kostentraeger/types.ts
@@ -57,9 +57,9 @@ export type Institution = {
     contacts?: Contact[],
     /** Address(es). Contains one to three addresses, (max) one for each type */
     addresses: Address[],
-    /** Details on where and with which protocol to send receipts. Undefined if this institution
-     *  does not accept any receipts directly */
-    transmissionMethods?: ReceiptTransmissionMethods,
+    /** Details on where to send receipts. Undefined if this institution does not accept any 
+     *  receipts directly */
+    transmission?: ReceiptTransmission,
     /** Link(s) to Kostenträger (=institutions that pays the receipts). 
      *  The institution with the IK as printed on the health-insurance card is not necessarily the
      *  institution that manages paying the receipts. Usually such things are done by a central 
@@ -158,12 +158,10 @@ export type CareProviderLocationSchluessel =
     FederalStateSchluesselWithoutNRWSchluessel | NRWSubdivisionSchluessel
 
 /** Simplified data model of UEM+DFU from the Kostenträger file with legacy stuff removed */
-export type ReceiptTransmissionMethods = {
-    /** Email address + charset to use to send receipts. Undefined if email is not accepted. */
-    email?: string | undefined,
-    /** FTAM address + charset to use to send receipts. Undefined if FTAM is not accepted. */
-    ftam?: string | undefined,
-    /** Charset in which the data must be transmitted (for email / FTAM) */
+export type ReceiptTransmission = {
+    /** Email address to use to send receipts. */
+    email: string,
+    /** Charset in which the data must be transmitted */
     zeichensatz: UebermittlungszeichensatzSchluessel
 }
 

--- a/tests/kostentraeger/index.spec.ts
+++ b/tests/kostentraeger/index.spec.ts
@@ -110,9 +110,7 @@ describe("Kostenträger index", () => {
         const datenannahmestelle = {
             ...base, 
             ik: "00000003",
-            transmissionMethods: {
-                paperReceipt: true,
-                machineReadablePaperReceipt: true,
+            transmission: {
                 email: "default@default.de",
                 zeichensatz: "I8"
             }
@@ -151,9 +149,7 @@ describe("Kostenträger index", () => {
         const untrustedDatenannahmestelle = {
             ...base, 
             ik: "00000004",
-            transmissionMethods: {
-                paperReceipt: true,
-                machineReadablePaperReceipt: true,
+            transmission: {
                 email: "default@default.de",
                 zeichensatz: "I8"
             }
@@ -657,9 +653,7 @@ const linksPapierAndDatenannahmeTo = (ik: string) => ({
 })
 
 const acceptsData = {
-    transmissionMethods: {
-        paperReceipt: true,
-        machineReadablePaperReceipt: true,
+    transmission: {
         email: "default@default.de",
         zeichensatz: "I8"
     }

--- a/tests/kostentraeger/transformer.spec.ts
+++ b/tests/kostentraeger/transformer.spec.ts
@@ -353,6 +353,109 @@ describe("kostentraeger transformer", () => {
         expect(json(transform(interchange).institutionList)).toEqual(json(expectedInstitutionList))
     })
 
+    it("validate messages for dependence on FTAM", () => {
+        const interchange: KOTRInterchange = {
+            issuerIK: "123456789",
+            filename: {
+                kassenart: "AO",
+                verfahren: "06",
+                validityStartDate: new Date("2018-05-05"),
+                version: 1
+            },
+            institutions: [
+            // 1. The Kostenträger
+            {
+                id: 1, 
+                idk: {
+                    ik: "999999999",
+                    institutionsart: "99",
+                    abbreviatedName: "short name"
+                },
+                vdt: { validityFrom: new Date("2000-20-20") },
+                fkt: { verarbeitungskennzeichenSchluessel: "01" },
+                nam: { index: 1, names: ["name"]},
+                ansList: [],
+                aspList: [],
+                dfuList: [],
+                uemList: [],
+                vkgList: [
+                    {   // link to Datenannahmestelle mit Entschlüsselungsbefugnis
+                        ikVerknuepfungsartSchluessel: "03",
+                        verknuepfungspartnerIK: "999999991",
+                        datenlieferungsartSchluessel: "07"
+                    }
+                ]
+            },
+            // 2. The Datenannahmestelle mit Entschlüsselungsbefugnis
+            {
+                id: 2, 
+                idk: {
+                    ik: "999999991",
+                    institutionsart: "99",
+                    abbreviatedName: "short name"
+                },
+                vdt: { validityFrom: new Date("2000-20-20") },
+                fkt: { verarbeitungskennzeichenSchluessel: "01" },
+                nam: { index: 1, names: ["name"]},
+                ansList: [],
+                aspList: [],
+                uemList: [
+                    {
+                        uebermittlungsmediumSchluessel: "1",
+                        uebermittlungsmediumParameterSchluessel: "00",
+                        uebermittlungszeichensatzSchluessel: "I8"
+                    }
+                ],
+                dfuList: [
+                    {   // only accept FTAM :-(
+                        index: 1,
+                        dfuProtokollSchluessel: "016",
+                        address: "ftam.blub-it.de:5000"
+                    }
+                ],
+                vkgList: [
+                    {   // link to Datenannahmestelle ohne Entschlüsselungsbefugnis
+                        ikVerknuepfungsartSchluessel: "02",
+                        verknuepfungspartnerIK: "999999992",
+                        datenlieferungsartSchluessel: "07"
+                    }
+                ]
+            },
+            // 3. The Datenannahmestelle ohne Entschlüsselungsbefugnis
+            {
+                id: 3, 
+                idk: {
+                    ik: "999999992",
+                    institutionsart: "99",
+                    abbreviatedName: "short name"
+                },
+                vdt: { validityFrom: new Date("2000-20-20") },
+                fkt: { verarbeitungskennzeichenSchluessel: "01" },
+                nam: { index: 1, names: ["name"]},
+                ansList: [],
+                aspList: [],
+                uemList: [
+                    {
+                        uebermittlungsmediumSchluessel: "1",
+                        uebermittlungsmediumParameterSchluessel: "00",
+                        uebermittlungszeichensatzSchluessel: "I8"
+                    }
+                ],
+                dfuList: [
+                    {   // only accept FTAM :-(
+                        index: 1,
+                        dfuProtokollSchluessel: "016",
+                        address: "ftam.blub-it.de:5000"
+                    }
+                ],
+                vkgList: []
+            }]
+        }
+
+        const result = transform(interchange)
+        // there should also not be any warnings parsing this
+        expect(result.warnings).toHaveLength(1)
+    })
 })
 
 /* need to compare the stringified and then parsed result because Javascript Date objects 

--- a/tests/kostentraeger/transformer.spec.ts
+++ b/tests/kostentraeger/transformer.spec.ts
@@ -41,13 +41,13 @@ describe("kostentraeger transformer", () => {
                 vkgList: [
                     {   // Kostenträger
                         ikVerknuepfungsartSchluessel: "01",
-                        verknuepfungspartnerIK: "555444333",
+                        verknuepfungspartnerIK: "999999999",
                         leistungserbringergruppeSchluessel: "6",
                         standortLeistungserbringerBundeslandSchluessel: "02",
                     },
                     {   // Datenannahmestelle ohne Entschlüsselungsbefugnis
                         ikVerknuepfungsartSchluessel: "02",
-                        verknuepfungspartnerIK: "112200000",
+                        verknuepfungspartnerIK: "999999999",
                         leistungserbringergruppeSchluessel: "6",
                         datenlieferungsartSchluessel: "07",
                         standortLeistungserbringerBundeslandSchluessel: "01",
@@ -55,13 +55,13 @@ describe("kostentraeger transformer", () => {
                     },
                     {   // Datenannahmestelle mit Entschlüsselungsbefugnis
                         ikVerknuepfungsartSchluessel: "03",
-                        verknuepfungspartnerIK: "112200001",
+                        verknuepfungspartnerIK: "999999999",
                         datenlieferungsartSchluessel: "07",
                         standortLeistungserbringerBundeslandSchluessel: "99"
                     },
                     {   // Machinenlesbare Belege Annahmestelle
                         ikVerknuepfungsartSchluessel: "09",
-                        verknuepfungspartnerIK: "334455667",
+                        verknuepfungspartnerIK: "999999999",
                         leistungserbringergruppeSchluessel: "5",
                         datenlieferungsartSchluessel: "29",
                         standortLeistungserbringerKVBezirkSchluessel: "38",
@@ -69,7 +69,7 @@ describe("kostentraeger transformer", () => {
                     },
                     {   // Papierannahmestelle
                         ikVerknuepfungsartSchluessel: "09",
-                        verknuepfungspartnerIK: "112233445",
+                        verknuepfungspartnerIK: "999999999",
                         leistungserbringergruppeSchluessel: "6",
                         datenlieferungsartSchluessel: "21"
                     },
@@ -164,31 +164,30 @@ describe("kostentraeger transformer", () => {
                         fieldOfWork: "Schabernack"
                     }
                 ],
-                transmissionMethods: {
+                transmission: {
                     email: "ok@go.de",
-                    ftam: "ftam.blub-it.de:5000",
                     zeichensatz: "I8"
                 },
                 kostentraegerLinks: [{
-                    ik: "555444333",
+                    ik: "999999999",
                     location: "HH",
                     sgbxiLeistungsart: "00"
                 }],
                 datenannahmestelleLinks: [{
-                    ik: "112200001"
+                    ik: "999999999"
                 }],
                 untrustedDatenannahmestelleLinks: [{
-                    ik: "112200000",
+                    ik: "999999999",
                     location: "SH",
                     sgbxiLeistungsart: "12"
                 }],
                 papierannahmestelleLinks: [{
-                    ik: "334455667",
+                    ik: "999999999",
                     location: "Nordrhein",
                     sgbvAbrechnungscode: "25",
                     paperTypes: PaperDataType.MachineReadableReceipt | PaperDataType.CostEstimate | PaperDataType.Prescription,
                 }, {
-                    ik: "112233445",
+                    ik: "999999999",
                     sgbxiLeistungsart: "00",
                     paperTypes: PaperDataType.Receipt,
                 }]


### PR DESCRIPTION
Closes #33 

Remove FTAM from data model, after checking (and generating warnings) if then it wouldn't be possible anymore to send data to any Datenannahmestelle.

Result: No warnings added except for those entries where the address is missing completely (#29)