### PR TITLE
type Leistung

### DIFF
--- a/src/sgb-xi/codes.ts
+++ b/src/sgb-xi/codes.ts
@@ -191,20 +191,27 @@ export const pflegesatzSchluessel = {
 }
 export type PflegesatzSchluessel = keyof typeof pflegesatzSchluessel
 
-// 2.7.5 Schlüssel Wegegebühren/Beförderungsentgelt-Art
-export const wegegebuehrenSchluessel = {
+/** 2.7.5 Schlüssel Wegegebühren/Beförderungsentgelt-Art */
+export const pauschaleWegegebuehrenSchluessel = {
     "01": "Tagespauschale",
     "02": "Monatspauschale",
     "03": "Einsatz- / Fahrtkostenpauschale",
+}
+export type PauschaleWegegebuehrenSchluessel = keyof typeof pauschaleWegegebuehrenSchluessel
+
+export const nichtPauschaleWegegebuehrenSchluessel = {
     "04": "gefahrene Kilometer",
 }
-export type WegegebuehrenSchluessel = keyof typeof wegegebuehrenSchluessel;
+export type NichtPauschaleWegegebuehrenSchluessel = keyof typeof nichtPauschaleWegegebuehrenSchluessel
 
-// 2.7.7 Schlüssel Leistung: Pauschale (Beratungsbesuch nach § 37 Abs. 3)
-export const pauschaleLeistungSchluessel = {
+export type WegegebuehrenSchluessel = 
+    PauschaleWegegebuehrenSchluessel | NichtPauschaleWegegebuehrenSchluessel
+
+/** 2.7.7 Schlüssel Leistung: Pauschale (Beratungsbesuch nach § 37 Abs. 3) */
+export const beratungsbesuchPauschaleLeistungSchluessel = {
     "1": "Einsatzpauschale"
 }
-export type PauschaleLeistungSchluessel = keyof typeof pauschaleLeistungSchluessel;
+export type BeratungsbesuchPauschaleLeistungSchluessel = keyof typeof beratungsbesuchPauschaleLeistungSchluessel
 
 /** 2.7.8 Schlüssel Leistung: Sonstige */
 export const sonstigeLeistungSchluessel = {
@@ -212,7 +219,7 @@ export const sonstigeLeistungSchluessel = {
 }
 export type SonstigeLeistungSchluessel = keyof typeof sonstigeLeistungSchluessel
 
-// 2.8 Schlüssel Kennzeichen Pflegehilfsmittel
+/** 2.8 Schlüssel Kennzeichen Pflegehilfsmittel */
 export const pflegehilfsmittelSchluessel = {
     "": "nicht zutreffend",
     "00": "Neulieferung",

--- a/src/sgb-xi/codes.ts
+++ b/src/sgb-xi/codes.ts
@@ -192,20 +192,13 @@ export const pflegesatzSchluessel = {
 export type PflegesatzSchluessel = keyof typeof pflegesatzSchluessel
 
 /** 2.7.5 Schlüssel Wegegebühren/Beförderungsentgelt-Art */
-export const pauschaleWegegebuehrenSchluessel = {
+export const wegegebuehrenSchluessel = {
     "01": "Tagespauschale",
     "02": "Monatspauschale",
     "03": "Einsatz- / Fahrtkostenpauschale",
-}
-export type PauschaleWegegebuehrenSchluessel = keyof typeof pauschaleWegegebuehrenSchluessel
-
-export const nichtPauschaleWegegebuehrenSchluessel = {
     "04": "gefahrene Kilometer",
 }
-export type NichtPauschaleWegegebuehrenSchluessel = keyof typeof nichtPauschaleWegegebuehrenSchluessel
-
-export type WegegebuehrenSchluessel = 
-    PauschaleWegegebuehrenSchluessel | NichtPauschaleWegegebuehrenSchluessel
+export type WegegebuehrenSchluessel = keyof typeof wegegebuehrenSchluessel
 
 /** 2.7.7 Schlüssel Leistung: Pauschale (Beratungsbesuch nach § 37 Abs. 3) */
 export const beratungsbesuchPauschaleLeistungSchluessel = {

--- a/src/sgb-xi/segments.ts
+++ b/src/sgb-xi/segments.ts
@@ -272,9 +272,9 @@ const getLeistungDetails = (leistung: Leistung): string | undefined => {
             return leistung.leistungsEnde ? time(leistung.leistungsEnde) : "00"
         case "02":
         case "03":
-            return time(leistung.leistungsEnde)
+            return time(leistung.leistungsEnde!!)
         case "04":
-            return day(leistung.leistungsBeginn) + day(leistung.leistungsEnde)
+            return day(leistung.leistungsBeginn!!) + day(leistung.leistungsEnde!!)
         case "06":
             if (leistung.wegegebuehren == "04") {
                 return Math.round(leistung.gefahreneKilometer).toString() // integer from 0-9999

--- a/src/sgb-xi/segments.ts
+++ b/src/sgb-xi/segments.ts
@@ -216,50 +216,75 @@ export const ESK = (
     leistungsBeginn ? time(leistungsBeginn) : ""
 );
 
-// ELS is insanely complex: leistung and several parameters depend on verguetungsart
-export const ELS = ({
-    leistungsart,
-    verguetungsart,
-    qualifikationsabhaengigeVerguetung,
-    leistung,
-    einzelpreis,
-    anzahl,
-    leistungsBeginn, // for verguetungsart 04
-    leistungsEnde, // for verguetungsart 01, 02, 03, 04
-    gefahreneKilometer, // for verguetungsart 06 with leistung 04
-    punktwert,
-    punktzahl,
-}: Leistung) => {
-    let details = "00";
+export const ELS = (leistung: Leistung) => segment(
+    "ELS",
+    [
+        leistung.leistungsart,
+        leistung.verguetungsart,
+        leistung.qualifikationsabhaengigeVerguetung,
+        getLeistungSchluessel(leistung)
+    ].join(":"),
+    price(leistung.einzelpreis),
+    number(leistung.punktwert, 5),
+    number(leistung.punktzahl, 0),
+    getLeistungDetails(leistung),
+    number(leistung.anzahl, 2)
+)
 
-    if (verguetungsart == "01") {
-        details = leistungsEnde ? time(leistungsEnde) : "00";
-    } else if (verguetungsart == "02" && leistungsEnde) {
-        details = time(leistungsEnde);
-    } else if (verguetungsart == "03" && leistungsEnde) {
-        details = time(leistungsEnde);
-    } else if (verguetungsart == "04" && leistungsBeginn && leistungsEnde) {
-        details = day(leistungsBeginn) + day(leistungsEnde);
-    } else if (verguetungsart == "06" && leistung == "04"
-            && gefahreneKilometer != undefined) {
-        details = number(gefahreneKilometer, 0)
+/** see codes.ts - 2.7 Schlüssel Leistung */
+const getLeistungSchluessel = (leistung: Leistung): string | undefined => {
+    switch(leistung.verguetungsart) {
+        case "01": 
+            return mask(leistung.leistungskomplex) // 3-character string
+        case "02":
+            return leistung.zeiteinheit + leistung.zeitart
+        case "03":
+        case "04":
+            return leistung.pflegesatz
+        case "05":
+            return mask(leistung.positionsnummer) // 10-character string
+        case "06":
+            return leistung.wegegebuehren
+        case "08":
+            return "1" // see codes.ts - 2.7.7
+        case "99":
+            return "99" // see codes.ts - 2.7.8
     }
+}
 
-    return segment(
-        "ELS",
-        [
-            leistungsart,
-            verguetungsart,
-            qualifikationsabhaengigeVerguetung,
-            leistung
-        ].join(":"),
-        price(einzelpreis),
-        number(punktwert, 5),
-        number(punktzahl, 0),
-        details,
-        number(anzahl, 2)
-    )
-};
+/** documentation reads:
+ * 
+ *  Einzutragen ist bei Vergütungsart s. Schlüsselverzeichnis Anlage 3, Abschnitt 2.5. 
+ * 
+ *  01 => 00 bzw. Uhrzeit der Beendigung der Leistungserbringung (Uhrzeit), in der Form: hhmm
+ *  02 => die Uhrzeit der Beendigung der Leistungserbringung (Uhrzeit), in der Form: hhmm
+ *  03 => der Bis-Zeitraum (Uhrzeit). In der Form: hhmm
+ *  04 => der Vom/Bis-Zeitraum (Von/Tag und Bis/Tag). In der Form: TTTT
+ *  05 => 00
+ *  06 => Wegegebühren-/Beförderungsentgeltart = 04 nach Schlüssel 2.7.5, die Anzahl der gefahrenen Kilometer, (es sind nur ganze Kilometer zu melden und kaufmännisch zu runden z. B. 3,40 Km, zu melden 3), sonst = 00 (bei SC 01-03),
+ *  07 => frei
+ *  08 => 00
+ *  99 => 00
+ */
+const getLeistungDetails = (leistung: Leistung): string | undefined => {
+    switch(leistung.verguetungsart) {
+        case "01": 
+            return leistung.leistungsEnde ? time(leistung.leistungsEnde) : "00"
+        case "02":
+        case "03":
+            return time(leistung.leistungsEnde)
+        case "04":
+            return day(leistung.leistungsBeginn) + day(leistung.leistungsEnde)
+        case "06":
+            if (leistung.wegegebuehren == "04") {
+                return Math.round(leistung.gefahreneKilometer).toString() // integer from 0-9999
+            } else {
+                return "00"
+            }
+        default:
+            return "00"
+    }
+}
 
 export const ZUS = (
     isLast: boolean,

--- a/src/sgb-xi/types.ts
+++ b/src/sgb-xi/types.ts
@@ -6,9 +6,8 @@ import {
 import { 
     AbrechnungscodeSchluessel,
     LeistungsartSchluessel,
-    MehrwertsteuerSchluessel, 
-    NichtPauschaleWegegebuehrenSchluessel, 
-    PauschaleWegegebuehrenSchluessel, 
+    MehrwertsteuerSchluessel,
+    WegegebuehrenSchluessel,
     PflegehilfsmittelSchluessel,
     PflegesatzSchluessel,
     QualifikationsabhaengigeVerguetungSchluessel,
@@ -160,19 +159,11 @@ export type PflegehilfsmittelLeistung = BaseLeistung & {
     positionsnummer: string
 }
 
-export type WegegebuehrenLeistung = 
-    PauschaleWegegebuehrenLeistung |
-    WegegebuehrenNachKilometerLeistung
-
-export type PauschaleWegegebuehrenLeistung = BaseLeistung & {
+export type WegegebuehrenLeistung = BaseLeistung & {
     verguetungsart: "06"
-    wegegebuehren: PauschaleWegegebuehrenSchluessel
-}
-
-export type WegegebuehrenNachKilometerLeistung = BaseLeistung & {
-    verguetungsart: "06"
-    wegegebuehren: NichtPauschaleWegegebuehrenSchluessel
-    gefahreneKilometer: number
+    wegegebuehren: WegegebuehrenSchluessel
+    /** mandatory if wegegebuehren == "04"; omitted for all other values of wegegebuehren */
+    gefahreneKilometer?: number
 }
 
 export type PauschaleLeistung = BaseLeistung & {

--- a/src/sgb-xi/types.ts
+++ b/src/sgb-xi/types.ts
@@ -7,12 +7,17 @@ import {
     AbrechnungscodeSchluessel,
     LeistungsartSchluessel,
     MehrwertsteuerSchluessel, 
+    NichtPauschaleWegegebuehrenSchluessel, 
+    PauschaleWegegebuehrenSchluessel, 
     PflegehilfsmittelSchluessel,
+    PflegesatzSchluessel,
     QualifikationsabhaengigeVerguetungSchluessel,
     RechnungsartSchluessel,
     TarifbereichSchluessel,
     UmsatzsteuerBefreiungSchluessel,
     VerguetungsartSchluessel,
+    ZeitartSchluessel,
+    ZeiteinheitSchluessel,
     ZuschlagsartSchluessel,
     ZuschlagsberechnungSchluessel,
     ZuschlagSchluessel,
@@ -93,23 +98,91 @@ export type Einsatz = {
     leistungen: Leistung[]
 }
 
-export type Leistung = {
+/** A Leistung is subdivided into the following different subtypes, each told apart by the 
+ *  "verguetungsart" field. Each Leistung requires a different set of fields to be specified.
+ */
+export type Leistung = 
+    LeistungskomplexverguetungLeistung |
+    ZeitverguetungLeistung |
+    TeilstationaerLeistung |
+    VollstationaerOderKurzzeitpflegeLeistung |
+    PflegehilfsmittelLeistung |
+    WegegebuehrenLeistung |
+    PauschaleLeistung |
+    SonstigeLeistung
+
+type BaseLeistung = {
     leistungsart: LeistungsartSchluessel
     verguetungsart: VerguetungsartSchluessel
     qualifikationsabhaengigeVerguetung: QualifikationsabhaengigeVerguetungSchluessel
-    /** Depending on verguetungsart a completely different field */
-    leistung: string
+
     /** Price of one service provided */
     einzelpreis: number
     /** Number of things done, f.e. 3x check blood pressure, 3x 15 minutes etc. */
     anzahl: number
-    leistungsBeginn?: Date // for verguetungsart 04 only
-    leistungsEnde?: Date // for verguetungsart 01, 02, 03, 04
-    gefahreneKilometer?: number // for verguetungsart 06 with leistung 04
     punktwert?: number
     punktzahl?: number
+
+    /** only mandatory for verguetungsart 04 */
+    leistungsBeginn?: Date
+    /** mandatory for verguetungsart 01, 02, 03, 04 */
+    leistungsEnde?: Date
+
     zuschlaege: Zuschlag[]
-    hilfsmittel?: Pflegehilfsmittel // for verguetungsart 05 only
+}
+
+export type LeistungskomplexverguetungLeistung = BaseLeistung & {
+    verguetungsart: "01"
+    /** 3-character current number of Leistungskomplex */
+    leistungskomplex: string
+}
+
+export type ZeitverguetungLeistung = BaseLeistung & {
+    verguetungsart: "02"
+    zeiteinheit: ZeiteinheitSchluessel
+    zeitart: ZeitartSchluessel
+}
+
+export type TeilstationaerLeistung = BaseLeistung & {
+    verguetungsart: "03"
+    pflegesatz: PflegesatzSchluessel
+}
+
+export type VollstationaerOderKurzzeitpflegeLeistung = BaseLeistung & {
+    verguetungsart: "04"
+    pflegesatz: PflegesatzSchluessel
+}
+
+export type PflegehilfsmittelLeistung = BaseLeistung & {
+    verguetungsart: "05"
+    hilfsmittel: Pflegehilfsmittel
+    /** Hilfsmittelpositionsnummer, see /hilfsmittelverzeichnis/types.ts  */
+    positionsnummer: string
+}
+
+export type WegegebuehrenLeistung = 
+    PauschaleWegegebuehrenLeistung |
+    WegegebuehrenNachKilometerLeistung
+
+export type PauschaleWegegebuehrenLeistung = BaseLeistung & {
+    verguetungsart: "06"
+    wegegebuehren: PauschaleWegegebuehrenSchluessel
+}
+
+export type WegegebuehrenNachKilometerLeistung = BaseLeistung & {
+    verguetungsart: "06"
+    wegegebuehren: NichtPauschaleWegegebuehrenSchluessel
+    gefahreneKilometer: number
+}
+
+export type PauschaleLeistung = BaseLeistung & {
+    verguetungsart: "08"
+    // there is only one code for Pauschale: "Einsatzspauschale" = "1", see codes.ts 2.7.7
+}
+
+export type SonstigeLeistung = BaseLeistung & {
+    verguetungsart: "99"
+    // there is only one code for Pauschale: "Sonstiges" = "99", see codes.ts 2.7.8
 }
 
 export type Zuschlag = {

--- a/src/sgb-xi/validation.ts
+++ b/src/sgb-xi/validation.ts
@@ -83,28 +83,29 @@ const constraintsLeistungByVerguetungsart = (leistung: Leistung) => {
     switch(leistung.verguetungsart) {
         case "01": return [
             isOptionalDate(leistung, "leistungsEnde"),
-            isChar(leistung, "leistung", 3), // leistung = Leistungskomplex
+            isChar(leistung, "leistungskomplex", 3)
         ]
         case "02": return [
             isDate(leistung, "leistungsEnde"),
-            isRequired(leistung, "leistung"), // leistung = ZeiteinheitSchluessel + ZeitartSchluessel
+            isRequired(leistung, "zeiteinheit"),
+            isRequired(leistung, "zeitart")
         ]
         case "03": return [
             isDate(leistung, "leistungsEnde"),
-            isRequired(leistung, "leistung"), // leistung = PflegesatzSchluessel
+            isRequired(leistung, "pflegesatz")
         ]
         case "04": return [
             isDate(leistung, "leistungsBeginn"),
             isDate(leistung, "leistungsEnde"),
-            isRequired(leistung, "leistung"), // leistung = PflegesatzSchluessel
+            isRequired(leistung, "pflegesatz")
         ]
         case "05": return [
             isRequired(leistung, "hilfsmittel"),
             ...valueConstraints(leistung, "hilfsmittel", constraintsPflegehilfsmittel),
-            isVarchar(leistung, "leistung", 10), // leistung = Positionsnummer
+            isVarchar(leistung, "positionsnummer", 10)
         ]
         case "06": 
-            if (leistung.leistung == "04") { // leistung = WegegebuehrenSchluessel
+            if (leistung.wegegebuehren == "04") { 
                 return [ isNumber(leistung, "gefahreneKilometer", 0, 1e4) ]
             } else {
                 return []

--- a/tests/samples/billingPayloads.ts
+++ b/tests/samples/billingPayloads.ts
@@ -5,15 +5,13 @@ import {
 import {
     BillingData,
     Invoice,
-    Leistung, 
     Leistungserbringer,
     LeistungskomplexverguetungLeistung,
     PauschaleLeistung,
-    PauschaleWegegebuehrenLeistung,
+    WegegebuehrenLeistung,
     PflegehilfsmittelLeistung,
     TeilstationaerLeistung,
     VollstationaerOderKurzzeitpflegeLeistung,
-    WegegebuehrenNachKilometerLeistung,
     ZeitverguetungLeistung, 
 } from "../../src/sgb-xi/types"
 
@@ -241,7 +239,7 @@ const zeitMitZuschlag: ZeitverguetungLeistung = {
         wert: 10,
     }],
 };
-const wegegebuehrenEinsatzpauschale: PauschaleWegegebuehrenLeistung = {
+const wegegebuehrenEinsatzpauschale: WegegebuehrenLeistung = {
     leistungsart: "01",
     verguetungsart: "06",
     qualifikationsabhaengigeVerguetung: "1",
@@ -250,7 +248,7 @@ const wegegebuehrenEinsatzpauschale: PauschaleWegegebuehrenLeistung = {
     anzahl: 1,
     zuschlaege: [],
 };
-const wegegebuehrenKilometer: WegegebuehrenNachKilometerLeistung = {
+const wegegebuehrenKilometer: WegegebuehrenLeistung = {
     leistungsart: "01",
     verguetungsart: "06",
     qualifikationsabhaengigeVerguetung: "1",

--- a/tests/samples/billingPayloads.ts
+++ b/tests/samples/billingPayloads.ts
@@ -6,7 +6,15 @@ import {
     BillingData,
     Invoice,
     Leistung, 
-    Leistungserbringer, 
+    Leistungserbringer,
+    LeistungskomplexverguetungLeistung,
+    PauschaleLeistung,
+    PauschaleWegegebuehrenLeistung,
+    PflegehilfsmittelLeistung,
+    TeilstationaerLeistung,
+    VollstationaerOderKurzzeitpflegeLeistung,
+    WegegebuehrenNachKilometerLeistung,
+    ZeitverguetungLeistung, 
 } from "../../src/sgb-xi/types"
 
 const leistungserbringer: Leistungserbringer[] = [{
@@ -189,11 +197,11 @@ const versicherte: Versicherter[] = [{
 
 // Leistungen
 
-const leistungskomplex: Leistung = {
+const leistungskomplex: LeistungskomplexverguetungLeistung = {
     leistungsart: "01",
     verguetungsart: "01",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "001",
+    leistungskomplex: "001",
     einzelpreis: 28.37,
     anzahl: 1,
     leistungsBeginn: new Date("2021-04-02T11:00"),
@@ -202,22 +210,24 @@ const leistungskomplex: Leistung = {
     punktzahl: 464,
     zuschlaege: [],
 };
-const zeitverguetung: Leistung = {
+const zeitverguetung: ZeitverguetungLeistung = {
     leistungsart: "01",
     verguetungsart: "02",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "13",
+    zeiteinheit: "1",
+    zeitart: "3",
     einzelpreis: 45.45,
     anzahl: 1,
     leistungsBeginn: new Date("2021-04-02T10:00"),
     leistungsEnde: new Date("2021-04-02T11:00"),
     zuschlaege: [],
 };
-const zeitMitZuschlag: Leistung = {
+const zeitMitZuschlag: ZeitverguetungLeistung = {
     leistungsart: "01",
     verguetungsart: "02",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "13",
+    zeiteinheit: "1",
+    zeitart: "3",
     einzelpreis: 45.45,
     anzahl: 1,
     leistungsBeginn: new Date("2021-04-02T10:00"),
@@ -231,30 +241,30 @@ const zeitMitZuschlag: Leistung = {
         wert: 10,
     }],
 };
-const wegegebuehrenEinsatzpauschale: Leistung = {
+const wegegebuehrenEinsatzpauschale: PauschaleWegegebuehrenLeistung = {
     leistungsart: "01",
     verguetungsart: "06",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "03",
+    wegegebuehren: "03",
     einzelpreis: 2,
     anzahl: 1,
     zuschlaege: [],
 };
-const wegegebuehrenKilometer: Leistung = {
+const wegegebuehrenKilometer: WegegebuehrenNachKilometerLeistung = {
     leistungsart: "01",
     verguetungsart: "06",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "04",
+    wegegebuehren: "04",
     einzelpreis: 0.4,
     anzahl: 1,
     gefahreneKilometer: 5,
     zuschlaege: [],
 };
-const pflegehilfsmittel: Leistung = {
+const pflegehilfsmittel: PflegehilfsmittelLeistung = {
     leistungsart: "06",
     verguetungsart: "05",
     qualifikationsabhaengigeVerguetung: "0",
-    leistung: "000000000",
+    positionsnummer: "000000000",
     einzelpreis: 123.45,
     anzahl: 1,
     zuschlaege: [],
@@ -267,33 +277,32 @@ const pflegehilfsmittel: Leistung = {
         bezeichnungPflegehilfsmittel: "Rollator",
     },
 };
-const beratungsbesuch: Leistung = {
+const beratungsbesuch: PauschaleLeistung = {
     leistungsart: "09",
     verguetungsart: "08",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "1",
     einzelpreis: 32,
     anzahl: 1,
     leistungsBeginn: new Date("2021-04-03T13:00"),
     leistungsEnde: new Date("2021-04-03T13:30"),
     zuschlaege: [],
 };
-const teilstationaer: Leistung = {
+const teilstationaer: TeilstationaerLeistung = {
     leistungsart: "02",
     verguetungsart: "03",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "01",
+    pflegesatz: "01",
     einzelpreis: 42.84,
     anzahl:1,
     leistungsBeginn: new Date("2021-04-02T10:00"),
     leistungsEnde: new Date("2021-04-02T18:00"),
     zuschlaege: [],
 };
-const kurzzeitpflege: Leistung = {
+const kurzzeitpflege: VollstationaerOderKurzzeitpflegeLeistung = {
     leistungsart: "04",
     verguetungsart: "04",
     qualifikationsabhaengigeVerguetung: "1",
-    leistung: "00",
+    pflegesatz: "00",
     einzelpreis: 234.56,
     anzahl: 8,
     leistungsBeginn: new Date("2021-04-03T12:00"),


### PR DESCRIPTION
### Issue
- the `leistung` field for the `ELS` segment should contain a completely different information depending on the type of Leistung, i.e. depending on the value of `verguetungsart`. This makes it to cite yourself "insanely complex"
- there is no documentation in PAID to help what kind of data is expected depending on the value of `verguetungsart`. As a user of this library, one would need to read through the GKV docs again to find out what one is expected to specify.
- the current Leistung type is in this regard misleading because it suggests that e.g. the Wegegeld or the Pflegehilfsmittel used is to be (or can be) specified in one Leistung together with e.g. a Leistung nach Zeitvergütung. This is not the case. To bill Zeitvergütung + Wegegeld + Pflegehilfsmittel, three Leistungen need to be billed, not one.

### Solution
Just type it. A Leistung can be a "Wegegeld Leistung", a "Zeitvergütung Leistung", a "Pflegehilfsmittel Leistung" etc.
Depending on the type of Leistung, different fields are mandatory and the fields are named and typed according to what should be filled in.