### PR TITLE
Certificates in kostentraeger file

### DIFF
--- a/src/kostentraeger/json_serializer.ts
+++ b/src/kostentraeger/json_serializer.ts
@@ -1,10 +1,18 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from "./pki/utils";
 import { InstitutionList } from "./types";
+import { AsnSerializer, AsnParser } from "@peculiar/asn1-schema"
+import { Certificate } from "@peculiar/asn1-x509"
 
 export function serializeInstitutionLists(data: InstitutionList[], space?: string|number|undefined): string {
     return JSON.stringify(data, (key: string, value: any): any => {
         switch(key) {
-            case "publicKey": return arrayBufferToBase64(value as ArrayBuffer)
+            case "certificates": 
+                if (value) {
+                    const certificates = value as Array<Certificate>
+                    return certificates.map(certificate => 
+                        arrayBufferToBase64(AsnSerializer.serialize(certificate))
+                    )
+                }
         }
         return value
     }, space)
@@ -13,10 +21,15 @@ export function serializeInstitutionLists(data: InstitutionList[], space?: strin
 export function deserializeInstitutionLists(text: string): InstitutionList[] {
     return JSON.parse(text, (key: string, value: any): any => {
         switch(key) {
-            case "publicKey":         return base64ToArrayBuffer(value as string)
-            case "validityStartDate": return new Date(value as string)
-            case "validityFrom":      return new Date(value as string)
-            case "validityTo":        return new Date(value as string)
+            case "certificates":
+                if (value) {
+                    const certificatePEMs = value as Array<string>
+                    return certificatePEMs.map(pem =>
+                        AsnParser.parse(base64ToArrayBuffer(pem), Certificate)
+                    )
+                }
+            case "validityStartDate": 
+                return new Date(value as string)
         }
         return value
     })

--- a/src/kostentraeger/pki/parser.ts
+++ b/src/kostentraeger/pki/parser.ts
@@ -2,22 +2,22 @@
  * (see /docs/documents.md for more info)
  */
 import { AsnParser } from "@peculiar/asn1-schema"
-import { Certificate, id_kp_serverAuth } from "@peculiar/asn1-x509"
-import { PublicKeyInfo } from "./types"
+import { Certificate } from "@peculiar/asn1-x509"
 import { base64ToArrayBuffer } from "./utils"
 
 /** Parses a string that consists of number of PEM-encoded certificates (of Datenannahmestellen)
- *  separated by newlines into a map of IK -> PublicKeyInfo[].
+ *  separated by newlines into a map of IK -> Certificate[].
  */
-export default function parse(str: string): Map<string, PublicKeyInfo[]> {
-    const result = new Map<string, PublicKeyInfo[]>()
+export default function parse(str: string): Map<string, Certificate[]> {
+    const result = new Map<string, Certificate[]>()
     parseCertificates(str).forEach((certificate) => {
-        const pKeyInfos = certificateToPublicKeyInfo(certificate)
-        pKeyInfos.forEach(([ik, pKeyInfo]) => {
+        validateCertificate(certificate)
+        const iks = getCertificateIKs(certificate)
+        iks.forEach(ik => {
             if (!result.has(ik)) {
-                result.set(ik, [pKeyInfo])
+                result.set(ik, [certificate])
             } else {
-                result.get(ik)!.push(pKeyInfo)
+                result.get(ik)!.push(certificate)
             }
         })
     })
@@ -25,31 +25,31 @@ export default function parse(str: string): Map<string, PublicKeyInfo[]> {
     return result
 }
 
-function certificateToPublicKeyInfo(certificate: Certificate): [string, PublicKeyInfo][] {
+function validateCertificate(certificate: Certificate) {
     const cert = certificate.tbsCertificate
+    // expecting that all public keys use the RSA algorithm ( http://oid-info.com/get/1.2.840.113549.1.1.1 )
+    // (out of lazyness/KISS to handle more then what is necessary)
+    if (cert.subjectPublicKeyInfo.algorithm.algorithm != '1.2.840.113549.1.1.1') {
+        throw new Error(`Expected public key to use RSA encryption (oid = 1.2.840.113549.1.1.1) but was oid = ${cert.subjectPublicKeyInfo.algorithm.algorithm}`)
+    }
+    if (cert.subjectPublicKeyInfo.algorithm.parameters) {
+        throw new Error(`Expected no parameters for public key RSA encryption`)
+    }
+}
+
+/** Returns the IK(s) the certificates are valid for. 
+ *  
+ *  The documentation is a bit unclear whether a certificate can be valid for multiple IKs. Since
+ *  it is possible by the data structure, better play it safe and support that
+*/
+function getCertificateIKs(certificate: Certificate): string[] {
     // See page 32 of Gemeinsame Grundsätze Technik, Anlage 16
     // Organizational Unit ( see http://oid-info.com/get/2.5.4.11 )
-    // documentation is a bit unclear - could be that one certificate may be valid for multiple IKs
-    const iks = cert.subject
+    const iks = certificate.tbsCertificate.subject
         .filter((name) => name[0].type == '2.5.4.11' && name[0].value.printableString?.startsWith("IK"))
         .map((name) => name[0]!.value!.printableString!.substring(2))
 
-    return iks.map(ik => {
-        // expecting that all public keys use the RSA algorithm ( http://oid-info.com/get/1.2.840.113549.1.1.1 )
-        // (out of lazyness/KISS to handle more then what is necessary)
-        if (cert.subjectPublicKeyInfo.algorithm.algorithm != '1.2.840.113549.1.1.1') {
-            throw new Error(`Expected public key to use RSA encryption (oid = 1.2.840.113549.1.1.1) but was oid = ${cert.subjectPublicKeyInfo.algorithm.algorithm}`)
-        }
-        if (cert.subjectPublicKeyInfo.algorithm.parameters) {
-            throw new Error(`Expected no parameters for public key RSA encryption`)
-        }
-
-        return [ik, {
-            validityFrom: cert.validity.notBefore.getTime(),
-            validityTo: cert.validity.notAfter.getTime(),
-            publicKey: cert.subjectPublicKeyInfo.subjectPublicKey
-        }]
-    })
+    return iks
 }
 
 function parseCertificates(str: string): Certificate[] {

--- a/src/kostentraeger/pki/types.ts
+++ b/src/kostentraeger/pki/types.ts
@@ -1,9 +1,0 @@
-/** Public key */
-export type PublicKeyInfo = {
-    /** date from which the key may be used */
-    validityFrom: Date,
-    /** date until which the key may be used */
-    validityTo: Date
-    /** array buffer with public key (RSA) */
-    publicKey: ArrayBuffer
-}

--- a/src/kostentraeger/types.ts
+++ b/src/kostentraeger/types.ts
@@ -1,11 +1,10 @@
 import { 
     KostentraegerSGBVAbrechnungscodeSchluessel,
     KostentraegerSGBXILeistungsartSchluessel,
-    LeistungserbringergruppeSchluessel, 
-    UebermittlungszeichensatzSchluessel 
+    LeistungserbringergruppeSchluessel
 } from "./edifact/codes"
 import { KassenartSchluessel } from "./filename/codes"
-import { PublicKeyInfo } from "./pki/types"
+import { Certificate } from '@peculiar/asn1-x509'
 
 /**
  * These types represent the data from Kostentraeger file(s) cast into a (more) accessible data model
@@ -65,10 +64,10 @@ export type Institution = {
     /** Email where to send receipts. Undefined if this institution does not accept any 
      *  receipts directly */
     transmissionEmail?: string,
-    /** Public key(s) to use for encrypting to this IK, if any. One institution may have several
-     *  public keys, with overlapping validity dates
+    /** Certificate(s) to use for encrypting to this IK, if any. One institution may have several
+     *  certificates, with overlapping validity dates
      */
-    publicKeys?: PublicKeyInfo[],
+    certificates?: Certificate[],
     /** Link(s) to Kostenträger (=institutions that pays the receipts). 
      *  The institution with the IK as printed on the health-insurance card is not necessarily the
      *  institution that manages paying the receipts. Usually such things are done by a central 

--- a/tests/kostentraeger/index.spec.ts
+++ b/tests/kostentraeger/index.spec.ts
@@ -4,13 +4,15 @@ import {
     InstitutionListsIndex,
     Leistungsart
 } from "../../src/kostentraeger/index"
-import { PublicKeyInfo } from "../../src/kostentraeger/pki/types"
 import { 
     CareProviderLocationSchluessel,
     Institution,
     InstitutionList,
     PaperDataType
 } from "../../src/kostentraeger/types"
+import { base64ToArrayBuffer } from "../../src/kostentraeger/pki/utils"
+import { AsnParser } from "@peculiar/asn1-schema"
+import { Certificate, Time } from "@peculiar/asn1-x509"
 
 describe("Kostenträger index", () => {
 
@@ -26,7 +28,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kasse,
             encryptTo: kasse,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kasse 
         })
     })
@@ -44,7 +46,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kasse,
             encryptTo: kasse,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kasse 
         })
     })
@@ -73,7 +75,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse1,
             kostentraeger: kasse3,
             encryptTo: kasse3,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kasse3 
         })
     })
@@ -97,7 +99,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse1,
             kostentraeger: kasse2,
             encryptTo: kasse2,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kasse2 
         })
     })
@@ -120,15 +122,15 @@ describe("Kostenträger index", () => {
         const datenannahmestelle = {
             ...base, 
             ik: "00000003",
-            ...usesDefaultPublicKey
             transmissionEmail: "default@default.de",
+            ...usesDefaultCertificate
         } as Institution
 
         expect(findForData([institutionListOf([pflegekasse, kostentraeger, datenannahmestelle])], "00000001")).toEqual({
             pflegekasse: pflegekasse,
             kostentraeger: kostentraeger,
             encryptTo: datenannahmestelle,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: datenannahmestelle 
         })
     })
@@ -154,7 +156,7 @@ describe("Kostenträger index", () => {
             untrustedDatenannahmestelleLinks: [{
                 ik: "00000004"
             }],
-            ...usesDefaultPublicKey
+            ...usesDefaultCertificate
         } as Institution
         const untrustedDatenannahmestelle = {
             ...base, 
@@ -171,7 +173,7 @@ describe("Kostenträger index", () => {
             pflegekasse: pflegekasse,
             kostentraeger: kostentraeger,
             encryptTo: trustedDatenannahmestelle,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: untrustedDatenannahmestelle 
         })
     })
@@ -202,13 +204,13 @@ describe("Kostenträger index", () => {
         expect(findForData(
             [{
                 ...institutionListOf([simple]),
-                validityStartDate: new Date("2010-02-01"), // older
+                validityStartDate: new Date("2021-01-01"), // older
             },{
                 ...institutionListOf( [{...simple, name: "new name"}]),
-                validityStartDate: new Date("2011-02-01"), // newer
+                validityStartDate: new Date("2021-03-01"), // newer
             }], 
             defaultIK,
-            { date: new Date("2016-01-01") }
+            { date: new Date("2021-04-01") }
         )?.pflegekasse?.name).toEqual("new name")
     })
 
@@ -305,7 +307,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger2,
             encryptTo: kostentraeger2,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger2
         })
 
@@ -313,7 +315,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger3,
             encryptTo: kostentraeger3,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger3
         })
     })
@@ -343,7 +345,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger,
             encryptTo: kostentraeger,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger
         })
     })
@@ -381,7 +383,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger2,
             encryptTo: kostentraeger2,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger2
         })
 
@@ -389,7 +391,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger3,
             encryptTo: kostentraeger3,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger3
         })
     })
@@ -430,7 +432,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger2,
             encryptTo: kostentraeger2,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger2
         })
 
@@ -438,7 +440,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger3,
             encryptTo: kostentraeger3,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger3
         })
     })
@@ -469,14 +471,14 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger,
             encryptTo: kostentraeger,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger
         })
         expect(findForData(institutionLists, "00000001", { leistungsart: { sgbvAbrechnungscode: "32" }})).toEqual({
             pflegekasse: kasse,
             kostentraeger: kostentraeger,
             encryptTo: kostentraeger,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger
         })
         expect(findForData(institutionLists, "00000001", { leistungsart: { sgbvAbrechnungscode: "41" }})).toEqual(undefined)
@@ -522,7 +524,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger,
             encryptTo: kostentraeger,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger
         })
     })
@@ -563,7 +565,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger2,
             encryptTo: kostentraeger2,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger2
         })
 
@@ -576,7 +578,7 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kostentraeger2,
             encryptTo: kostentraeger2,
-            publicKey: defaultPublicKey,
+            certificate: defaultCertificate,
             sendTo: kostentraeger2
         })
     })
@@ -632,30 +634,28 @@ describe("Kostenträger index", () => {
         })
     })
 
-    it("excludes results for datenannahmestelle without public key", () => {
+    it("excludes results for datenannahmestelle without certificate", () => {
         const kasse = { 
             ...base, 
             ...acceptsData,
             ...linksPapierAndDatenannahmeTo("00000001"),
             ik: "00000001",
-            publicKeys: []
+            certificates: []
         } as Institution
 
         expect(findForData([institutionListOf([kasse])], "00000001")).toBeUndefined()
     })
 
-    it("excludes results for datenannahmestelle with expired public key", () => {
-        const expiredKeyInfo: PublicKeyInfo = {
-            validityFrom: new Date("2010-01-01"),
-            validityTo: new Date("2012-01-01"),
-            publicKey: new ArrayBuffer(8)
-        }
+    it("excludes results for datenannahmestelle with expired certificate", () => {
+        const expiredCertificate: Certificate = parseCertificate(certificatePEM)
+        expiredCertificate.tbsCertificate.validity.notBefore = new Time(new Date("2010-01-01"))
+        expiredCertificate.tbsCertificate.validity.notAfter = new Time(new Date("2012-01-01"))
 
         const kasse = { 
             ...base, 
             ...acceptsData,
             ...linksPapierAndDatenannahmeTo("00000001"),
-            publicKeys: [expiredKeyInfo],
+            certificates: [expiredCertificate],
             ik: "00000001"
         } as Institution
 
@@ -664,23 +664,20 @@ describe("Kostenträger index", () => {
         })).toBeUndefined()
     })
 
-    it("finds kostentraeger and uses the newer public key for result if there are several", () => {
-        const oldKeyInfo: PublicKeyInfo = {
-            validityFrom: new Date("2010-01-01"),
-            validityTo: new Date("2020-01-01"),
-            publicKey: new ArrayBuffer(8)
-        }
-        const newKeyInfo: PublicKeyInfo = {
-            validityFrom: new Date("2010-01-01"),
-            validityTo: new Date("2022-01-01"),
-            publicKey: new ArrayBuffer(9)
-        }
+    it("finds kostentraeger and uses the newer certificate for result if there are several", () => {
+        const oldCertificate: Certificate = parseCertificate(certificatePEM)
+        oldCertificate.tbsCertificate.validity.notBefore = new Time(new Date("2010-01-01"))
+        oldCertificate.tbsCertificate.validity.notAfter = new Time(new Date("2020-01-01"))
+        
+        const newCertificate: Certificate = parseCertificate(certificatePEM)
+        newCertificate.tbsCertificate.validity.notBefore = new Time(new Date("2010-01-01"))
+        newCertificate.tbsCertificate.validity.notAfter = new Time(new Date("2022-01-01"))
 
         const kasse = { 
             ...base, 
             ...acceptsData,
             ...linksPapierAndDatenannahmeTo("00000001"),
-            publicKeys: [oldKeyInfo, newKeyInfo],
+            certificates: [oldCertificate, newCertificate],
             ik: "00000001"
         } as Institution
 
@@ -690,14 +687,36 @@ describe("Kostenträger index", () => {
             pflegekasse: kasse,
             kostentraeger: kasse,
             encryptTo: kasse,
-            publicKey: newKeyInfo.publicKey,
+            certificate: newCertificate,
             sendTo: kasse 
         })
     })
 })
 
+const parseCertificate = (certPEM: string): Certificate =>
+    AsnParser.parse(base64ToArrayBuffer(certPEM), Certificate)
+
+const certificatePEM = `MIIDTjCCAjagAwIBAgIDAnxUMA0GCSqGSIb3DQEBCwUAMEkxCzAJBgNVBAYTAkRF
+MTowOAYDVQQKEzFJVFNHIFRydXN0Q2VudGVyIGZ1ZXIgc29uc3RpZ2UgTGVpc3R1
+bmdzZXJicmluZ2VyMB4XDTIwMTEyNDAwMDAwMFoXDTIzMDEwODIzNTk1OVowgYkx
+CzAJBgNVBAYTAkRFMTowOAYDVQQKEzFJVFNHIFRydXN0Q2VudGVyIGZ1ZXIgc29u
+c3RpZ2UgTGVpc3R1bmdzZXJicmluZ2VyMQ0wCwYDVQQLEwR2ZGVrMRQwEgYDVQQL
+EwtJSzEwOTk3OTk3ODEZMBcGA1UEAxMQRHIuIEhlaWtvIFN0YW1lcjCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAIAI9oynbhMHVe16zbUXGfdtNfC7a8WJ
+60nLaOXWnSvzCU81/gTz59jhi5i3y8lxR63hVeJuHl5/fY4z28tlMDQwX/V5z4iZ
+y8m75bo/SWu5kjmSETW0a0St5bq56kPTOJhxPvONF5nQfGuZGPw3Y6jsu2osCIVB
+ZQYWGihfL1hadbNQaalO0ZKYRu6FlUA6GfHtmzLnnQLVuAAUA6LMnaj0s9oBgwUQ
+oLuPrqe9pFdBKl+iEyg0/FC2fY7jy+dAgXsGQMDtY5sk0l0b7t7NFOzOwwPaeZrk
+u6oRKV9VSILMgSIHy7gLcBa8n4fuYM+4Bzf9oItMQQr+VuMjxe+UAWMCAwEAATAN
+BgkqhkiG9w0BAQsFAAOCAQEAOz8znqhmVw7g6RsENcOqu7UtjbdEitRd9aAW4hiz
+WJbbPv1rCU6+cFA8vCiQYdZagl8xrZrYyCpx+JUqQFkDUuq2kdQRgeAnQTggNV+K
+Xs702G+AMB3GmulPdlIPTN7YXQXoCiIJgsxn/CKveQYyYXuMdRJw/9GJJR9FatkJ
+xkG7EX7PaWOpimA/+U40PRyJ4etxclFNVuBbefQ/cWCHQhupY7hewdaK2yIXyXvd
+xAITd32OHKn7H/rEl220hwCPuGFUUvvoEtXn2i77dequl7BG3ceikkmjsdueqUxv
+3Ggt+TSxF2vu3ZXzDT1AjV7TFTLX7ClDQMXdUIn/nBF14g==`
+
 const defaultIK: string = "00000000"
-const defaultPublicKey: ArrayBuffer = new ArrayBuffer(111)
+const defaultCertificate = parseCertificate(certificatePEM)
 
 const institutionListOf = (institutions: Institution[]): InstitutionList => ({
     issuerIK: "00000000",
@@ -734,16 +753,12 @@ const linksPapierAndDatenannahmeTo = (ik: string) => ({
     }]
 })
 
-const usesDefaultPublicKey = {
-    publicKeys: [{
-        validityFrom: new Date("2010-01-01"),
-        validityTo: new Date("2090-01-01"),
-        publicKey: defaultPublicKey
-    }]
+const usesDefaultCertificate = {
+    certificates: [defaultCertificate]
 }
 
 const acceptsData = {
-    ...usesDefaultPublicKey,
+    ...usesDefaultCertificate,
     transmissionEmail: "default@default.de"
 }
 

--- a/tests/kostentraeger/json_serializer.spec.ts
+++ b/tests/kostentraeger/json_serializer.spec.ts
@@ -1,9 +1,11 @@
 import { deserializeInstitutionLists, serializeInstitutionLists } from "../../src/kostentraeger/json_serializer"
 import { base64ToArrayBuffer } from "../../src/kostentraeger/pki/utils"
 import { InstitutionList } from "../../src/kostentraeger/types"
+import { AsnParser, AsnSerializer } from "@peculiar/asn1-schema"
+import { Certificate } from "@peculiar/asn1-x509"
 
 
-describe("Institution lists with public keys JSON serializer", () => {
+describe("Institution lists with certificates JSON serializer", () => {
 
     it("serialize and deserialize", () => {
 
@@ -18,11 +20,7 @@ describe("Institution lists with public keys JSON serializer", () => {
                 name: "very long name",
                 // no validityFrom, so we test if it works correctly if property is undefined
                 validityTo: new Date("2088-10-10"),
-                publicKeys: [{
-                    validityFrom: new Date("2010-10-10"),
-                    validityTo: new Date("2020-12-12"),
-                    publicKey: base64ToArrayBuffer("TG9yZW0gaXBzb20gZG9sb3IgZXN0")
-                }],
+                certificates: [certificate],
                 addresses: [
                     { postcode: 12345, place: "Humburg" }
                 ],
@@ -35,8 +33,8 @@ describe("Institution lists with public keys JSON serializer", () => {
         const str2 = serializeInstitutionLists(list2)
 
         arrayBufferEquals( 
-            list1[0]!.institutions[0]!.publicKeys![0]!.publicKey,
-            list2[0]!.institutions[0]!.publicKeys![0]!.publicKey
+            AsnSerializer.serialize(list1[0]!.institutions[0]!.certificates![0]!),
+            AsnSerializer.serialize(list2[0]!.institutions[0]!.certificates![0]!)
         )
         // we cannot equal the institution list directly cause same dates do not equal
         expect(str2).toEqual(str)
@@ -54,3 +52,26 @@ function arrayBufferEquals (buf1: ArrayBuffer, buf2: ArrayBuffer)
     }
     return true
 }
+
+const certificate = AsnParser.parse(
+    base64ToArrayBuffer(
+`MIIDTjCCAjagAwIBAgIDAnxUMA0GCSqGSIb3DQEBCwUAMEkxCzAJBgNVBAYTAkRF
+MTowOAYDVQQKEzFJVFNHIFRydXN0Q2VudGVyIGZ1ZXIgc29uc3RpZ2UgTGVpc3R1
+bmdzZXJicmluZ2VyMB4XDTIwMTEyNDAwMDAwMFoXDTIzMDEwODIzNTk1OVowgYkx
+CzAJBgNVBAYTAkRFMTowOAYDVQQKEzFJVFNHIFRydXN0Q2VudGVyIGZ1ZXIgc29u
+c3RpZ2UgTGVpc3R1bmdzZXJicmluZ2VyMQ0wCwYDVQQLEwR2ZGVrMRQwEgYDVQQL
+EwtJSzEwOTk3OTk3ODEZMBcGA1UEAxMQRHIuIEhlaWtvIFN0YW1lcjCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAIAI9oynbhMHVe16zbUXGfdtNfC7a8WJ
+60nLaOXWnSvzCU81/gTz59jhi5i3y8lxR63hVeJuHl5/fY4z28tlMDQwX/V5z4iZ
+y8m75bo/SWu5kjmSETW0a0St5bq56kPTOJhxPvONF5nQfGuZGPw3Y6jsu2osCIVB
+ZQYWGihfL1hadbNQaalO0ZKYRu6FlUA6GfHtmzLnnQLVuAAUA6LMnaj0s9oBgwUQ
+oLuPrqe9pFdBKl+iEyg0/FC2fY7jy+dAgXsGQMDtY5sk0l0b7t7NFOzOwwPaeZrk
+u6oRKV9VSILMgSIHy7gLcBa8n4fuYM+4Bzf9oItMQQr+VuMjxe+UAWMCAwEAATAN
+BgkqhkiG9w0BAQsFAAOCAQEAOz8znqhmVw7g6RsENcOqu7UtjbdEitRd9aAW4hiz
+WJbbPv1rCU6+cFA8vCiQYdZagl8xrZrYyCpx+JUqQFkDUuq2kdQRgeAnQTggNV+K
+Xs702G+AMB3GmulPdlIPTN7YXQXoCiIJgsxn/CKveQYyYXuMdRJw/9GJJR9FatkJ
+xkG7EX7PaWOpimA/+U40PRyJ4etxclFNVuBbefQ/cWCHQhupY7hewdaK2yIXyXvd
+xAITd32OHKn7H/rEl220hwCPuGFUUvvoEtXn2i77dequl7BG3ceikkmjsdueqUxv
+3Ggt+TSxF2vu3ZXzDT1AjV7TFTLX7ClDQMXdUIn/nBF14g==`),
+Certificate
+)

--- a/tests/kostentraeger/pki/parser.spec.ts
+++ b/tests/kostentraeger/pki/parser.spec.ts
@@ -1,32 +1,23 @@
 import parse from "../../../src/kostentraeger/pki/parser"
+import { AsnSerializer } from "@peculiar/asn1-schema"
 import { base64ToArrayBuffer } from "../../../src/kostentraeger/pki/utils"
 
 describe("certificates parser", () => {
 
     it("parse two certificates", () => {
-        const pkeyMap = parse(twoCertificatesInPEM)
+        const certificatesByIK = parse(twoCertificatesInPEM)
         
-        const info1 = pkeyMap.get("109979978")!
+        const info1 = certificatesByIK.get("109979978")!
         expect(info1).toHaveLength(1)
+        expect(AsnSerializer.serialize(info1[0])!).toEqual(base64ToArrayBuffer(certificate1PEM))
 
-        expect(info1[0]!.publicKey).toEqual(base64ToArrayBuffer(
-            "MIIBCgKCAQEAgAj2jKduEwdV7XrNtRcZ92018LtrxYnrScto5dadK/MJTzX+BPPn2OGLmLfLyXFHreFV4m4eXn99jjPby2UwNDBf9XnPiJnLybvluj9Ja7mSOZIRNbRrRK3lurnqQ9M4mHE+840XmdB8a5kY/DdjqOy7aiwIhUFlBhYaKF8vWFp1s1BpqU7RkphG7oWVQDoZ8e2bMuedAtW4ABQDosydqPSz2gGDBRCgu4+up72kV0EqX6ITKDT8ULZ9juPL50CBewZAwO1jmyTSXRvu3s0U7M7DA9p5muS7qhEpX1VIgsyBIgfLuAtwFryfh+5gz7gHN/2gi0xBCv5W4yPF75QBYwIDAQAB"
-        ))
-        expect(info1[0]!.validityFrom.toISOString()).toEqual("2020-11-24T00:00:00.000Z")
-        expect(info1[0]!.validityTo.toISOString()).toEqual("2023-01-08T23:59:59.000Z")
-
-        const info2 = pkeyMap.get("109905003")!
+        const info2 = certificatesByIK.get("109905003")!
         expect(info2).toHaveLength(1)
-
-        expect(info2[0]!.publicKey).toEqual(base64ToArrayBuffer(
-            "MIICCgKCAgEAgCQvTcBf2rSezyfcv8SeGOaWU9CL3GXlW2+uCc6QmPLUgTB/p26f4e61mYWk4osxcZqaDk7oeaRR1F+NNQbX41GdzNzbRg/wplIwbme4X2JrOMgDPKdTGTeDmOhXweaallSVcc414l7ethaEHbI4OI4Hm9aJSj1NV/a6TcOMUhJtxPJrZzvC9NFgdSYrI0QZ78Aed9A+W+79WyKJ59AMbCWzwDRNeB1tajWoxcbuMbd/Szdysdlxot4VEmki6s7Es5CfEJOKzX7iCpQltQzMuk+Y6UDbyJ/kpvRxcUbz0MpRxxpsBdJ/V9P7/Ub2gVVxqKgjIKtVOe3FIat1NZqeQmablvjfyHZ7KjLFdl24L6BadSFWMM3DDZ3dnYroE+iXRWLrp9/YWWGOD+bzCQTY4i3sa17B8cqceJ1takHpVSpxREEJ9lSwToQ2PsGuSdFtXm1XQr6JSi7qh0EeRiT6KSRiMqxpsSv4teKt09RxRszYTEiiMYxXe1uKHqFgn1oQ+X1eQ3PSIRzHZ/9K6Mvp+HlD6jzFHDmovl5QTbDD/Al8mDSaU1lhRMGk/9redyUfEx/G3B+4soMdpcKyLkLzQS1xkJ/BipdqFzl11GO6ONx8GR6y8h6EmJWcSkVyp6MHQf/+bo29hj944ZBcmQSNSN7NozZDeOVIFcoQY9zpwHkCAwEAAQ=="
-        ))
-        expect(info2[0]!.validityFrom.toISOString()).toEqual("2018-11-14T00:00:00.000Z")
-        expect(info2[0]!.validityTo.toISOString()).toEqual("2021-12-31T23:59:59.000Z")
+        expect(AsnSerializer.serialize(info2[0])!).toEqual(base64ToArrayBuffer(certificate2PEM))
     })
 })
 
-const twoCertificatesInPEM = 
+const certificate1PEM = 
 `MIIDTjCCAjagAwIBAgIDAnxUMA0GCSqGSIb3DQEBCwUAMEkxCzAJBgNVBAYTAkRF
 MTowOAYDVQQKEzFJVFNHIFRydXN0Q2VudGVyIGZ1ZXIgc29uc3RpZ2UgTGVpc3R1
 bmdzZXJicmluZ2VyMB4XDTIwMTEyNDAwMDAwMFoXDTIzMDEwODIzNTk1OVowgYkx
@@ -44,9 +35,10 @@ WJbbPv1rCU6+cFA8vCiQYdZagl8xrZrYyCpx+JUqQFkDUuq2kdQRgeAnQTggNV+K
 Xs702G+AMB3GmulPdlIPTN7YXQXoCiIJgsxn/CKveQYyYXuMdRJw/9GJJR9FatkJ
 xkG7EX7PaWOpimA/+U40PRyJ4etxclFNVuBbefQ/cWCHQhupY7hewdaK2yIXyXvd
 xAITd32OHKn7H/rEl220hwCPuGFUUvvoEtXn2i77dequl7BG3ceikkmjsdueqUxv
-3Ggt+TSxF2vu3ZXzDT1AjV7TFTLX7ClDQMXdUIn/nBF14g==
+3Ggt+TSxF2vu3ZXzDT1AjV7TFTLX7ClDQMXdUIn/nBF14g==`
 
-MIIF1TCCA42gAwIBAgIDAw14MD0GCSqGSIb3DQEBCjAwoA0wCwYJYIZIAWUDBAIB
+const certificate2PEM = 
+`MIIF1TCCA42gAwIBAgIDAw14MD0GCSqGSIb3DQEBCjAwoA0wCwYJYIZIAWUDBAIB
 oRowGAYJKoZIhvcNAQEIMAsGCWCGSAFlAwQCAaIDAgEgMEkxCzAJBgNVBAYTAkRF
 MTowOAYDVQQKEzFJVFNHIFRydXN0Q2VudGVyIGZ1ZXIgc29uc3RpZ2UgTGVpc3R1
 bmdzZXJicmluZ2VyMB4XDTE4MTExNDAwMDAwMFoXDTIxMTIzMTIzNTk1OVowgbAx
@@ -77,6 +69,11 @@ t9Nxx6ZhvdzazPLLs3WbnH/kUCjbhHYNeWvSAPQ0mrOh/EuFP5NiXqucxnvQx/Kq
 mIUG8Egca5ztCjr0F+XYTvrXM4L/RWaQQ3LslPLWTW8oHwTUytgcGGQHiDlv6vjq
 vHCs7GJuxjLcjRRYkf8Ck+hpRK+9JaT7BbxAPILEaRJN/K3rTyKDtakAWFjWhdMJ
 lv9V4Ip794XGRzPNZDeh/F4qg/NUCRI/YimhOa4vF+x10FP7hOITBIAncb3fCO5A
-qF7l6fgFaTTV
+qF7l6fgFaTTV`
+
+const twoCertificatesInPEM = 
+`${certificate1PEM}
+
+${certificate2PEM}
 
 `

--- a/tests/kostentraeger/transformer.spec.ts
+++ b/tests/kostentraeger/transformer.spec.ts
@@ -1,5 +1,5 @@
+import { Certificate } from "@peculiar/asn1-x509"
 import { KOTRInterchange } from "../../src/kostentraeger/edifact/segments"
-import { PublicKeyInfo } from "../../src/kostentraeger/pki/types"
 import transform from "../../src/kostentraeger/transformer"
 import { InstitutionList, PaperDataType } from "../../src/kostentraeger/types"
 
@@ -141,12 +141,8 @@ describe("kostentraeger transformer", () => {
             }]
         }
 
-        const pkeyMap = new Map<string, PublicKeyInfo[]>()
-        pkeyMap.set("999999999", [{
-            validityFrom: new Date("2018-05-05"),
-            validityTo: new Date("2088-10-10"),
-            publicKey: new ArrayBuffer(8)
-        }])
+        const certificatesByIK = new Map<string, Certificate[]>()
+        certificatesByIK.set("999999999", [])
 
         const expectedInstitutionList: InstitutionList = {
             issuerIK: "123456789",
@@ -173,7 +169,7 @@ describe("kostentraeger transformer", () => {
                     }
                 ],
                 transmissionEmail: "ok@go.de",
-                publicKeys: pkeyMap.get("999999999"),
+                certificates: certificatesByIK.get("999999999"),
                 kostentraegerLinks: [{
                     ik: "999999999",
                     location: "HH",
@@ -200,7 +196,7 @@ describe("kostentraeger transformer", () => {
             }],
         }
 
-        const result = transform(pkeyMap, interchange)
+        const result = transform(certificatesByIK, interchange)
         // there should also not be any warnings parsing this
         expect(result.warnings).toEqual([])
 
@@ -458,14 +454,10 @@ describe("kostentraeger transformer", () => {
             }]
         }
 
-        const pkeyMap = new Map<string, PublicKeyInfo[]>()
-        pkeyMap.set("999999991", [{
-            validityFrom: new Date("2018-05-05"),
-            validityTo: new Date("2088-10-10"),
-            publicKey: new ArrayBuffer(8)
-        }])
+        const certificatesByIK = new Map<string, Certificate[]>()
+        certificatesByIK.set("999999991", [])
 
-        const result = transform(pkeyMap, interchange)
+        const result = transform(certificatesByIK, interchange)
         // there should also not be any warnings parsing this
         expect(result.warnings).toHaveLength(1)
     })


### PR DESCRIPTION
Instead of a base64 encoded public key and validity from/to dates as JSON, we now put the whole base64 encoded certificate into the kostentraeger.json.

Reason: The whole certificate is necessary for encryption because the certificate should be included in the transmission as well.